### PR TITLE
[fix/#7] workflows 파일 수정 (IAM 지역 변경)

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -56,6 +56,6 @@ jobs:
           application_name: epilog-develop
           environment_name: Epilog-develop-env
           version_label: github-action-${{ steps.current-time.outputs.formattedTime }}
-          region: ap-northeast-1
+          region: ap-northeast-2
           deployment_package: deploy/deploy.zip
           wait_for_deployment: false


### PR DESCRIPTION
### 내용
> git actions가 배포 중 Beanstalk Deploy에서 IAM 권한 문제로 인해 작동을 멈췄습니다.

### 한 일
- workflows의 job 중 하나인 Beanstalk Deploy의 region을 ap-northeast-1 > ap-northeast-2로 수정했습니다.