### PR TITLE
[fix/#111] 일지작성 기분/운동 직접입력 필드 확인 방법 변경

### DIFF
--- a/src/main/java/com/epi/epilog/app/service/logs/LogCommandService.java
+++ b/src/main/java/com/epi/epilog/app/service/logs/LogCommandService.java
@@ -76,7 +76,8 @@ public class LogCommandService {
                                 .log(log)
                                 .type(moodRequest.getType() != null ? moodRequest.getType() : "")
                                 .details(moodRequest.getDetails())
-                                .detailsState(moodRequest.getDetails() != null)
+                                .detailsState(moodRequest.getType().equals("직접입력")
+                                        ?true : false)
                                 .build())
                         .collect(Collectors.toList());
                 logMoodRepository.saveAll(logMoods);
@@ -86,9 +87,10 @@ public class LogCommandService {
                 List<LogExercise> logExerciseList = form.getExercise().stream()
                         .map(exercise -> LogExercise.builder()
                                 .log(log)
-                                .type(exercise.getType() != null ? exercise.getType() : "")
+                                .type(exercise.getType() != null ? exercise.getType() : null)
                                 .details(exercise.getDetails())
-                                .detailsState(exercise.getDetails() != null)
+                                .detailsState(exercise.getType().equals("직접입력")
+                                        ?true : false)
                                 .build())
                         .collect(Collectors.toList());
                 logExerciseRepository.saveAll(logExerciseList);


### PR DESCRIPTION
### 문제
> 직접입력 선택 후 텍스트박스 빈 값으로 보냈을 때 제대로 처리하지 못함