### PR TITLE
[Feat/DL-16] Swagger 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,63 +1,63 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.10'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.10'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.epi'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-	all {
-		exclude group: 'commons-logging', module: 'commons-logging'
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    all {
+        exclude group: 'commons-logging', module: 'commons-logging'
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	implementation 'org.apache.commons:commons-csv:1.8'
-	implementation 'com.google.firebase:firebase-admin:9.2.0'
-	implementation 'mysql:mysql-connector-java:8.0.32'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	implementation 'org.json:json:20230227'
-	implementation 'net.nurigo:sdk:4.2.7'
-//	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.modelmapper:modelmapper:2.3.8'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation 'org.xhtmlrenderer:flying-saucer-pdf:9.1.22'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.apache.commons:commons-csv:1.8'
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
+    implementation 'mysql:mysql-connector-java:8.0.32'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'org.json:json:20230227'
+    implementation 'net.nurigo:sdk:4.2.7'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.modelmapper:modelmapper:2.3.8'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.xhtmlrenderer:flying-saucer-pdf:9.1.22'
 }
 
 tasks.named('bootBuildImage') {
-	builder = 'paketobuildpacks/builder-jammy-base:latest'
+    builder = 'paketobuildpacks/builder-jammy-base:latest'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 jar {
-	enabled = false
+    enabled = false
 }

--- a/src/main/java/com/epi/epilog/app/controller/AuthController.java
+++ b/src/main/java/com/epi/epilog/app/controller/AuthController.java
@@ -29,15 +29,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final AuthService authService;
 
-    /**
-     * 회원가입
-     *
-     * @param form
-     * @return
-     */
     @Operation(summary = "회원가입", description = "모바일 회원가입")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = AuthFormDto.SignUpResponseDto.class)))
+            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
     })
     @PostMapping("/signup")
     public ResponseEntity<AuthFormDto.SignUpResponseDto> signup(@Valid @RequestBody AuthFormDto.SignupFormDto form) {
@@ -47,16 +41,10 @@ public class AuthController {
                 .body(signUpResponseDto);
     }
 
-    /**
-     * 모바일 로그인
-     *
-     * @param form
-     * @return
-     */
     @Operation(summary = "모바일 로그인")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "모바일 로그인 성공", content = @Content(schema = @Schema(implementation = String.class))),
-            @ApiResponse(responseCode = "401", description = "모바일 로그인 실패", content = @Content(schema = @Schema(implementation = com.epi.epilog.global.exception.ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "모바일 로그인 성공"),
+            @ApiResponse(responseCode = "401", description = "모바일 로그인 실패 - 인증 실패", content = @Content(schema = @Schema(implementation = com.epi.epilog.global.exception.ErrorResponse.class))),
     })
     @PostMapping("/login")
     public ResponseEntity<String> partientLogin(@Valid @RequestBody AuthFormDto.PatientLoginFormDto form) {
@@ -64,16 +52,10 @@ public class AuthController {
         return ResponseEntity.ok(token);
     }
 
-    /**
-     * 워치 로그인
-     *
-     * @param form
-     * @return
-     */
     @Operation(summary = "워치 로그인")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "워치 로그인 성공", content = @Content(schema = @Schema(implementation = String.class))),
-            @ApiResponse(responseCode = "401", description = "워치 로그인 실패", content = @Content(schema = @Schema(implementation = com.epi.epilog.global.exception.ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "워치 로그인 성공"),
+            @ApiResponse(responseCode = "401", description = "워치 로그인 실패 - 인증 실패", content = @Content(schema = @Schema(implementation = com.epi.epilog.global.exception.ErrorResponse.class)))
     })
     @PostMapping("/login/code")
     public ResponseEntity<String> partientLogin(@Valid @RequestBody AuthFormDto.ProtectorLoginFormDto form) {
@@ -81,15 +63,9 @@ public class AuthController {
         return ResponseEntity.ok(token);
     }
 
-    /**
-     * 닉네임 중복 검사
-     *
-     * @param userId
-     * @return
-     */
     @Operation(summary = "닉네임 중복 검사")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "닉네임 중복 검사 성공", content = @Content(schema = @Schema(implementation = CommonResponseDto.CommonResponse.class)))
+            @ApiResponse(responseCode = "200", description = "닉네임 중복 검사 성공"),
     })
     @GetMapping("/validation")
     public CommonResponseDto.CommonResponse idValidationCheck(@RequestParam("id") String userId) {

--- a/src/main/java/com/epi/epilog/app/controller/AuthController.java
+++ b/src/main/java/com/epi/epilog/app/controller/AuthController.java
@@ -3,9 +3,18 @@ package com.epi.epilog.app.controller;
 import com.epi.epilog.app.dto.AuthFormDto;
 import com.epi.epilog.app.dto.CommonResponseDto;
 import com.epi.epilog.app.service.auth.AuthService;
+import com.google.api.Http;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,48 +25,74 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = "Auth", description = "계정 관련 API")
 public class AuthController {
     private final AuthService authService;
 
     /**
      * 회원가입
+     *
      * @param form
      * @return
      */
+    @Operation(summary = "회원가입", description = "모바일 회원가입")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = AuthFormDto.SignUpResponseDto.class)))
+    })
     @PostMapping("/signup")
-    public AuthFormDto.SignUpResponseDto signup(@Valid @RequestBody AuthFormDto.SignupFormDto form){
-        return authService.signUp(form);
+    public ResponseEntity<AuthFormDto.SignUpResponseDto> signup(@Valid @RequestBody AuthFormDto.SignupFormDto form) {
+        AuthFormDto.SignUpResponseDto signUpResponseDto = authService.signUp(form);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(signUpResponseDto);
     }
 
     /**
      * 모바일 로그인
+     *
      * @param form
      * @return
      */
+    @Operation(summary = "모바일 로그인")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "모바일 로그인 성공", content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "401", description = "모바일 로그인 실패", content = @Content(schema = @Schema(implementation = com.epi.epilog.global.exception.ErrorResponse.class)))
+    })
     @PostMapping("/login")
-    public ResponseEntity<String> partientLogin(@Valid @RequestBody AuthFormDto.PatientLoginFormDto form){
+    public ResponseEntity<String> partientLogin(@Valid @RequestBody AuthFormDto.PatientLoginFormDto form) {
         String token = authService.patientLogin(form);
         return ResponseEntity.ok(token);
     }
 
     /**
      * 워치 로그인
+     *
      * @param form
      * @return
      */
+    @Operation(summary = "워치 로그인")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "워치 로그인 성공", content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "401", description = "워치 로그인 실패", content = @Content(schema = @Schema(implementation = com.epi.epilog.global.exception.ErrorResponse.class)))
+    })
     @PostMapping("/login/code")
-    public ResponseEntity<String> partientLogin(@Valid @RequestBody AuthFormDto.ProtectorLoginFormDto form){
+    public ResponseEntity<String> partientLogin(@Valid @RequestBody AuthFormDto.ProtectorLoginFormDto form) {
         String token = authService.protectorLogin(form);
         return ResponseEntity.ok(token);
     }
 
     /**
      * 닉네임 중복 검사
+     *
      * @param userId
      * @return
      */
+    @Operation(summary = "닉네임 중복 검사")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 중복 검사 성공", content = @Content(schema = @Schema(implementation = CommonResponseDto.CommonResponse.class)))
+    })
     @GetMapping("/validation")
-    public CommonResponseDto.CommonResponse idValidationCheck(@RequestParam("id") String userId){
+    public CommonResponseDto.CommonResponse idValidationCheck(@RequestParam("id") String userId) {
         return authService.idValidationCheck(userId);
     }
 }

--- a/src/main/java/com/epi/epilog/app/controller/DiabetesController.java
+++ b/src/main/java/com/epi/epilog/app/controller/DiabetesController.java
@@ -5,10 +5,19 @@ import com.epi.epilog.app.dto.DiabetesRequestDto;
 import com.epi.epilog.app.dto.DiabetesResponseDto;
 import com.epi.epilog.app.service.logs.DiabetesCommandService;
 import com.epi.epilog.app.service.logs.DiabetesQueryService;
+import com.epi.epilog.global.exception.ErrorResponse;
 import com.epi.epilog.global.utils.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,31 +33,39 @@ import java.time.LocalDate;
 @RequestMapping("/api/diabetes")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "Diabetes", description = "당뇨 일지 관련 API(워치 전용)")
 public class DiabetesController {
     private final DiabetesCommandService diabetesCommandService;
     private final DiabetesQueryService diabetesQueryService;
 
-    /**
-     * 워치 일별 혈당 목록 조회
-     * @param date
-     * @return
-     */
+    @Operation(summary = "워치 일 별 혈당 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "워치 일 별 혈당 목록 조회 성공"),
+    })
     @GetMapping("/bloodsugars")
-    public DiabetesResponseDto.BloodSugarTodayResponse bloodSugarList(@RequestParam(value = "date", required = false) LocalDate date){
+    public DiabetesResponseDto.BloodSugarTodayResponse bloodSugarList(
+            @RequestParam(value = "date", required = false) LocalDate date) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        return diabetesQueryService.showBloodSugarList(userDetails.getMember(), date!=null?date:LocalDate.now());
+
+        return diabetesQueryService.showBloodSugarList(userDetails.getMember(), date != null ? date : LocalDate.now());
     }
 
-    /**
-     * 워치 혈당입력
-     * @param form
-     * @return
-     */
+    @Operation(summary = "워치 혈당 입력")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "워치 혈당 입력 성공"),
+            @ApiResponse(responseCode = "404", description = "워치 일 별 혈당 목록 조회 실패 - 유저 조회 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "400", description = "워치 일 별 혈당 목록 조회 실패 - 최대 입력 개수 초과", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
     @PostMapping("/bloodsugar")
-    public CommonResponseDto.CommonResponse createBloodSugar(@RequestBody @Valid DiabetesRequestDto.BloodSugarRequest form){
+    public ResponseEntity<CommonResponseDto.CommonResponse> createBloodSugar(
+            @RequestBody @Valid DiabetesRequestDto.BloodSugarRequest form) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        return diabetesCommandService.createBloodSugar(form, userDetails.getMember());
+
+        CommonResponseDto.CommonResponse bloodSugar = diabetesCommandService
+                .createBloodSugar(form, userDetails.getMember());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(bloodSugar);
     }
 }

--- a/src/main/java/com/epi/epilog/app/controller/FCMController.java
+++ b/src/main/java/com/epi/epilog/app/controller/FCMController.java
@@ -6,6 +6,8 @@ import com.epi.epilog.app.service.auth.FCMService;
 import com.epi.epilog.global.exception.ApiException;
 import com.epi.epilog.global.exception.ErrorCode;
 import com.epi.epilog.global.utils.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,14 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/fcm")
 @RequiredArgsConstructor
+@Tag(name="FCM", description = "FCM API")
 public class FCMController {
     private final FCMService fcmService;
 
-    /**
-     * token 저장
-     * @param form
-     * @return
-     */
+    @Operation(summary = "디바이스 토큰 저장")
     @PostMapping("/token")
     public CommonResponseDto.CommonResponse saveFCMToken(@RequestBody FCMDto.FCMRequestForm form) {
         try {

--- a/src/main/java/com/epi/epilog/app/controller/LogController.java
+++ b/src/main/java/com/epi/epilog/app/controller/LogController.java
@@ -164,8 +164,9 @@ public class LogController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         List<PdfData> entries = logQueryService.generatedPdfEntries(((CustomUserDetails) authentication.getPrincipal()), start, end);
+        ByteArrayOutputStream baos;
         try {
-            ByteArrayOutputStream baos = pdfService.createPdf("diabetes_log", entries);
+            baos = pdfService.createPdf("diabetes_log", entries);
 
         } catch (Exception e) {
             throw new ApiException(ErrorCode.FAIL_TO_CONVERSION_PDF);

--- a/src/main/java/com/epi/epilog/app/controller/LogController.java
+++ b/src/main/java/com/epi/epilog/app/controller/LogController.java
@@ -7,11 +7,21 @@ import com.epi.epilog.app.dto.PdfData;
 import com.epi.epilog.app.service.fall.PdfService;
 import com.epi.epilog.app.service.logs.LogCommandService;
 import com.epi.epilog.app.service.logs.LogQueryService;
+import com.epi.epilog.global.exception.ApiException;
+import com.epi.epilog.global.exception.ErrorCode;
+import com.epi.epilog.global.exception.ErrorResponse;
 import com.epi.epilog.global.utils.CustomUserDetails;
 import com.epi.epilog.global.utils.DateTimeConverter;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -32,21 +42,23 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/logs")
 @RequiredArgsConstructor
+@Tag(name = "Log", description = "일지 관련 API")
 public class LogController {
     private final LogQueryService logQueryService;
     private final LogCommandService logCommandService;
     private final PdfService pdfService;
 
-    /**
-     * 월별 일지 개수 조회
-     */
+    @Operation(summary = "월 별 일지 개수 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "월 별 일지 개수 조회 성공"),
+    })
     @GetMapping("/count")
-    public LogsResponseDto.MonthLogsCount monthLogsCount(@RequestParam(value = "date", required = false) String date){
+    public LogsResponseDto.MonthLogsCount monthLogsCount(@RequestParam(value = "date", required = false) String date) {
         LocalDate queryDate;
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (date == null) {
-             date  = DateTimeConverter.convertLocalDateToString(LocalDate.now());
+            date = DateTimeConverter.convertLocalDateToString(LocalDate.now());
         }
 
         queryDate = DateTimeConverter.convertToLocalDate(date);
@@ -56,14 +68,15 @@ public class LogController {
         return logsCount;
     }
 
-    /**
-     * 일별 일지 목록 조회
-     */
+    @Operation(summary = "일 별 일지 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일 별 일지 목록 조회 성공"),
+    })
     @GetMapping("")
-    public LogsResponseDto.DayLogsList dayLogList(@RequestParam(value = "date", required = false) String date){
+    public LogsResponseDto.DayLogsList dayLogList(@RequestParam(value = "date", required = false) String date) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (date == null){
+        if (date == null) {
             date = DateTimeConverter.convertLocalDateToString(LocalDate.now());
         }
 
@@ -73,14 +86,15 @@ public class LogController {
         return logQueryService.dayLogList(customUserDetails, queryDate);
     }
 
-    /**
-     * 일별 평균, 식전후 평균 혈당 조회
-     */
+    @Operation(summary = "일 별/식 전후 평균 혈당 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일 별/식 전후 평균 혈당 조회 성공"),
+    })
     @GetMapping("/bloodsugar/average")
-    public LogsResponseDto.DayAvgBloodSugar dayAvgBloodSugar(@RequestParam(value = "date", required = false)String date){
+    public LogsResponseDto.DayAvgBloodSugar dayAvgBloodSugar(@RequestParam(value = "date", required = false) String date) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (date == null){
+        if (date == null) {
             date = DateTimeConverter.convertLocalDateToString(LocalDate.now());
         }
         LocalDate queryDate = DateTimeConverter.convertToLocalDate(date);
@@ -89,11 +103,12 @@ public class LogController {
         return logQueryService.dayAvgBloodSugar(customUserDetails, queryDate);
     }
 
-    /**
-     * 일별 혈당 목록 조회
-     */
+    @Operation(summary = "일 별 혈당 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일 별 혈당 목록 조회 성공"),
+    })
     @GetMapping("/bloodsugar")
-    public LogsResponseDto.DayBloodSugarList getDayBloodSugarList(@RequestParam(value = "date", required = false)String date){
+    public LogsResponseDto.DayBloodSugarList getDayBloodSugarList(@RequestParam(value = "date", required = false) String date) {
         if (date == null) {
             date = DateTimeConverter.convertLocalDateToString(LocalDate.now());
         }
@@ -101,11 +116,12 @@ public class LogController {
         return logQueryService.dayBloodSugarList(((CustomUserDetails) authentication.getPrincipal()), date);
     }
 
-    /**
-     * 월별 체중, 체지방률 목록 조회
-     */
+    @Operation(summary = "월 별 체중, 체지방률 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "월 별 체중, 체지방률 목록 조회 성공"),
+    })
     @GetMapping("/weight")
-    public LogsResponseDto.MonthWeightList getMonthWeightList(@RequestParam(value="date", required = false)String date){
+    public LogsResponseDto.MonthWeightList getMonthWeightList(@RequestParam(value = "date", required = false) String date) {
         if (date == null) {
             date = DateTimeConverter.convertLocalDateToString(LocalDate.now());
         }
@@ -113,40 +129,47 @@ public class LogController {
         return logQueryService.getMonthWeightList(date, ((CustomUserDetails) authentication.getPrincipal()));
     }
 
-    /**
-     * 일지 등록
-     */
+    @Operation(summary = "일지 등록")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "일지 등록 성공"),
+            @ApiResponse(responseCode = "404", description = "일지 등록 실패 - 유저 찾기 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
     @PostMapping("")
-    public CommonResponseDto.CommonResponse createLog(@RequestBody LogsRequestDto.LogCreateForm form) {
+    public ResponseEntity<CommonResponseDto.CommonResponse> createLog(@RequestBody LogsRequestDto.LogCreateForm form) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return logCommandService.createLog( ((CustomUserDetails) authentication.getPrincipal()), form);
+        CommonResponseDto.CommonResponse log = logCommandService.createLog(((CustomUserDetails) authentication.getPrincipal()), form);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(log);
     }
 
-    /**
-     * 일지 상세 조회
-     */
+    @Operation(summary = "일지 상세 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일지 상세 조회 성공"),
+    })
     @GetMapping("/{logId}")
     public LogsResponseDto.DetailAllLog detailLog(@PathVariable("logId") Long id) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return logQueryService.getDetailLog( ((CustomUserDetails) authentication.getPrincipal()), id);
+        return logQueryService.getDetailLog(((CustomUserDetails) authentication.getPrincipal()), id);
     }
 
-    /**
-     * PDF 변환
-     * @param start 시작일
-     * @param end 마지막일
-     * @return
-     * @throws Exception
-     */
+    @Operation(summary = "PDF 변환")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "PDF 변환 성공"),
+            @ApiResponse(responseCode = "400", description = "PDF 변환 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
     @GetMapping("/convert")
-    public ResponseEntity<InputStreamResource> createdPDF(@RequestParam(value = "start", required = true)LocalDate start,
-                                                          @RequestParam(value = "end", required = true)LocalDate end) throws Exception{
+    public ResponseEntity<InputStreamResource> createdPDF(@RequestParam(value = "start", required = true) LocalDate start,
+                                                          @RequestParam(value = "end", required = true) LocalDate end) throws Exception {
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         List<PdfData> entries = logQueryService.generatedPdfEntries(((CustomUserDetails) authentication.getPrincipal()), start, end);
-        ByteArrayOutputStream baos = pdfService.createPdf("diabetes_log", entries);
+        try {
+            ByteArrayOutputStream baos = pdfService.createPdf("diabetes_log", entries);
 
+        } catch (Exception e) {
+            throw new ApiException(ErrorCode.FAIL_TO_CONVERSION_PDF);
+        }
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-Disposition", "inline; filename=diabetes_log.pdf");
 

--- a/src/main/java/com/epi/epilog/app/controller/MealsController.java
+++ b/src/main/java/com/epi/epilog/app/controller/MealsController.java
@@ -5,6 +5,10 @@ import com.epi.epilog.app.dto.MealsResponseDto;
 import com.epi.epilog.app.service.checklist.MealsCommandService;
 import com.epi.epilog.app.service.checklist.MealsQueryService;
 import com.epi.epilog.global.utils.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -22,31 +26,28 @@ import java.time.LocalDate;
 @RestController
 @RequestMapping("/api/meals")
 @RequiredArgsConstructor
+@Tag(name = "Meal", description = "식사 관리 API")
 public class MealsController {
     private final MealsQueryService mealsQueryService;
     private final MealsCommandService mealsCommandService;
 
-    /**
-     * 식사 체크리스트 조회
-     * @param date
-     * @return
-     */
+    @Operation(summary = "식사 체크리스트 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "식사 체크리스트 조회 성공")
+    })
     @GetMapping("")
-    public MealsResponseDto.ChecklistDto mealsChecklist(@RequestParam(value = "date", required = false)LocalDate date){
+    public MealsResponseDto.ChecklistDto mealsChecklist(@RequestParam(value = "date", required = false) LocalDate date) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        return mealsQueryService.mealsCheckList(userDetails.getMember(), date!=null?date:LocalDate.now());
+        return mealsQueryService.mealsCheckList(userDetails.getMember(), date != null ? date : LocalDate.now());
     }
 
-    /**
-     * 식사 체크리스트 상태 수정
-     * 유저 검증하는 절차 추가
-     * @param id
-     * @param form
-     * @return
-     */
+    @Operation(summary = "식사 체크리스트 상태 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "식사 체크리스트 상태 수정 성공")
+    })
     @PatchMapping("/{chklstId}")
-    public CommonResponseDto.CommonResponse medicineCheck(@PathVariable("chklstId")Long id, @RequestBody @Valid MealsResponseDto.MealChecklistUpdateDto form){
+    public CommonResponseDto.CommonResponse medicineCheck(@PathVariable("chklstId") Long id, @RequestBody @Valid MealsResponseDto.MealChecklistUpdateDto form) {
         return mealsCommandService.mealsCheck(id, form);
     }
 }

--- a/src/main/java/com/epi/epilog/app/controller/MedicationController.java
+++ b/src/main/java/com/epi/epilog/app/controller/MedicationController.java
@@ -5,9 +5,18 @@ import com.epi.epilog.app.dto.MedicationRequestDto;
 import com.epi.epilog.app.dto.MedicationResponseDto;
 import com.epi.epilog.app.service.checklist.MedicationCommandService;
 import com.epi.epilog.app.service.checklist.MedicationQueryService;
+import com.epi.epilog.global.exception.ErrorResponse;
 import com.epi.epilog.global.utils.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -23,56 +32,67 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/medications")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "Medication", description = "복약 관리 API")
 public class MedicationController {
     private final MedicationQueryService medicationQueryService;
     private final MedicationCommandService medicationCommandService;
 
-    /**
-     * 복용약 상세 조회
-     * @param medicationId
-     * @return
-     */
+    @Operation(summary = "복용약 상세 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "복용약 상세 조회 성공"),
+    })
     @GetMapping("/{mcId}")
-    public MedicationResponseDto.GetMedicationForm getMedicationDetails(@PathVariable("mcId")Long medicationId){
+    public MedicationResponseDto.GetMedicationForm getMedicationDetails(@PathVariable("mcId") Long medicationId) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userInfo = (CustomUserDetails) authentication.getPrincipal();
         return medicationQueryService.getMedicationDetails(medicationId, userInfo);
     }
 
-    /**
-     * 복용약 추가
-     * @param form
-     * @return
-     */
+    @Operation(summary = "복용약 추가")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "복용약 추가 성공"),
+            @ApiResponse(responseCode = "404", description = "복용약 추가 실패 - 유저 조회 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "400", description = "복용약 추가 실패 - 유효하지 않은 포맷", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
     @PostMapping("")
-    public CommonResponseDto.CommonResponse addMedication(@RequestBody MedicationRequestDto.MedicationAddedForm form){
+    public ResponseEntity<CommonResponseDto.CommonResponse> addMedication(
+            @RequestBody MedicationRequestDto.MedicationAddedForm form) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userInfo = (CustomUserDetails) authentication.getPrincipal();
-        return medicationCommandService.addMedication(userInfo, form);
+
+        CommonResponseDto.CommonResponse commonResponse = medicationCommandService.addMedication(userInfo, form);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(commonResponse);
     }
 
-    /**
-     * 복용약 수정
-     * @param medicationId
-     * @param form
-     * @return
-     */
+    @Operation(summary = "복용약 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "복용약 수정 성공"),
+            @ApiResponse(responseCode = "404", description = "복용약 수정 실패 - 약 조회 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "복용약 수정 실패 - 유저 조회 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "복용약 수정 실패 - 유저 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "400", description = "복용약 수정 실패 - 유효하지 않은 포맷", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
     @PatchMapping("/{mcId}")
-    public CommonResponseDto.CommonResponse patchMedication(@PathVariable("mcId")Long medicationId, @RequestBody MedicationRequestDto.MedicationAddedForm form) {
+    public ResponseEntity<CommonResponseDto.CommonResponse> patchMedication(@PathVariable("mcId") Long medicationId, @RequestBody MedicationRequestDto.MedicationAddedForm form) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userInfo = (CustomUserDetails) authentication.getPrincipal();
-        return medicationCommandService.patchMedication(userInfo, medicationId, form);
+
+        CommonResponseDto.CommonResponse commonResponse = medicationCommandService.patchMedication(userInfo, medicationId, form);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(commonResponse);
     }
 
-    /**
-     * 복용약 삭제
-     * @param medicationId
-     * @return
-     */
+    @Operation(summary = "복용약 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "복용약 삭제 성공")
+    })
     @DeleteMapping("/{mcId}")
-    public CommonResponseDto.CommonResponse deleteMedication(@PathVariable("mcId")Long medicationId) {
+    public ResponseEntity<Void> deleteMedication(@PathVariable("mcId") Long medicationId) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userInfo = (CustomUserDetails) authentication.getPrincipal();
-        return medicationCommandService.deleteMedication(userInfo, medicationId);
+
+        medicationCommandService.deleteMedication(userInfo, medicationId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/epi/epilog/app/controller/MedicationController.java
+++ b/src/main/java/com/epi/epilog/app/controller/MedicationController.java
@@ -67,20 +67,18 @@ public class MedicationController {
 
     @Operation(summary = "복용약 수정")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "복용약 수정 성공"),
+            @ApiResponse(responseCode = "200", description = "복용약 수정 성공"),
             @ApiResponse(responseCode = "404", description = "복용약 수정 실패 - 약 조회 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "복용약 수정 실패 - 유저 조회 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "403", description = "복용약 수정 실패 - 유저 인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "400", description = "복용약 수정 실패 - 유효하지 않은 포맷", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @PatchMapping("/{mcId}")
-    public ResponseEntity<CommonResponseDto.CommonResponse> patchMedication(@PathVariable("mcId") Long medicationId, @RequestBody MedicationRequestDto.MedicationAddedForm form) {
+    public CommonResponseDto.CommonResponse patchMedication(@PathVariable("mcId") Long medicationId, @RequestBody MedicationRequestDto.MedicationAddedForm form) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userInfo = (CustomUserDetails) authentication.getPrincipal();
 
-        CommonResponseDto.CommonResponse commonResponse = medicationCommandService.patchMedication(userInfo, medicationId, form);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(commonResponse);
+        return medicationCommandService.patchMedication(userInfo, medicationId, form);
     }
 
     @Operation(summary = "복용약 삭제")

--- a/src/main/java/com/epi/epilog/app/controller/MedicineController.java
+++ b/src/main/java/com/epi/epilog/app/controller/MedicineController.java
@@ -53,15 +53,13 @@ public class MedicineController {
      */
     @Operation(summary = "복약 체크리스트 상태 수정")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "복약 체크리스트 상태 수정 성공")
+            @ApiResponse(responseCode = "200", description = "복약 체크리스트 상태 수정 성공")
     })
     @PatchMapping("/{chklstId}")
-    public ResponseEntity<CommonResponseDto.CommonResponse> medicineCheck(@PathVariable("chklstId") Long id, @RequestBody @Valid MedicationResponseDto.MedicineChecklistUpdateDto form) {
+    public CommonResponseDto.CommonResponse medicineCheck(@PathVariable("chklstId") Long id, @RequestBody @Valid MedicationResponseDto.MedicineChecklistUpdateDto form) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userInfo = (CustomUserDetails) authentication.getPrincipal();
 
-        CommonResponseDto.CommonResponse commonResponse = medicineCommandService.medicineCheck(id, form, userInfo);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(commonResponse);
+        return medicineCommandService.medicineCheck(id, form, userInfo);
     }
 }

--- a/src/main/java/com/epi/epilog/app/controller/MedicineController.java
+++ b/src/main/java/com/epi/epilog/app/controller/MedicineController.java
@@ -5,8 +5,14 @@ import com.epi.epilog.app.dto.MedicationResponseDto;
 import com.epi.epilog.app.service.checklist.MedicineCommandService;
 import com.epi.epilog.app.service.checklist.MedicineQueryService;
 import com.epi.epilog.global.utils.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,32 +28,40 @@ import java.time.LocalDate;
 @RestController
 @RequestMapping("/api/medicines")
 @RequiredArgsConstructor
+@Tag(name = "Medicine", description = "복용약 체크리스트 API")
 public class MedicineController {
     private final MedicineCommandService medicineCommandService;
     private final MedicineQueryService medicineQueryService;
 
-    /**
-     * 일별 복약 체크리스트 목록 조회
-     * @param date
-     * @return
-     */
+    @Operation(summary = "일 별 복약 체크리스트 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일 별 복약 체크리스트 목록 조회 성공")
+    })
     @GetMapping("")
-    public MedicationResponseDto.ChecklistDto showMedicines(@RequestParam(value = "date", required = false)LocalDate date) {
+    public MedicationResponseDto.ChecklistDto showMedicines(@RequestParam(value = "date", required = false) LocalDate date) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        return medicineQueryService.medicineChecklist(date!=null?date:LocalDate.now(), userDetails.getMember());
+        return medicineQueryService.medicineChecklist(date != null ? date : LocalDate.now(), userDetails.getMember());
     }
 
     /**
      * 복약 체크리스트 상태 수정
+     *
      * @param id
      * @param form
      * @return
      */
+    @Operation(summary = "복약 체크리스트 상태 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "복약 체크리스트 상태 수정 성공")
+    })
     @PatchMapping("/{chklstId}")
-    public CommonResponseDto.CommonResponse medicineCheck(@PathVariable("chklstId")Long id, @RequestBody @Valid MedicationResponseDto.MedicineChecklistUpdateDto form){
+    public ResponseEntity<CommonResponseDto.CommonResponse> medicineCheck(@PathVariable("chklstId") Long id, @RequestBody @Valid MedicationResponseDto.MedicineChecklistUpdateDto form) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userInfo = (CustomUserDetails) authentication.getPrincipal();
-        return medicineCommandService.medicineCheck(id, form, userInfo);
+
+        CommonResponseDto.CommonResponse commonResponse = medicineCommandService.medicineCheck(id, form, userInfo);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(commonResponse);
     }
 }

--- a/src/main/java/com/epi/epilog/app/controller/StatusTestController.java
+++ b/src/main/java/com/epi/epilog/app/controller/StatusTestController.java
@@ -1,5 +1,6 @@
 package com.epi.epilog.app.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,22 +8,25 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Slf4j
+@Tag(name = "테스트", description = "헬스 체크 테스트 전용 API")
 public class StatusTestController {
     /**
      * elastic beanstalk health check
+     *
      * @return
      */
     @GetMapping("/test")
-    public ResponseEntity<String> testAPI(){
+    public ResponseEntity<String> testAPI() {
         return ResponseEntity.ok("successful");
     }
 
     /**
      * spring security test
+     *
      * @return
      */
     @GetMapping("/auth/test")
-    public ResponseEntity<String> testAuthAPI(){
+    public ResponseEntity<String> testAuthAPI() {
         return ResponseEntity.ok("successful");
     }
 }

--- a/src/main/java/com/epi/epilog/app/controller/StatusTestController.java
+++ b/src/main/java/com/epi/epilog/app/controller/StatusTestController.java
@@ -8,23 +8,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Slf4j
-@Tag(name = "테스트", description = "헬스 체크 테스트 전용 API")
+@Tag(name = "Test", description = "헬스 체크 테스트 전용 API")
 public class StatusTestController {
-    /**
-     * elastic beanstalk health check
-     *
-     * @return
-     */
     @GetMapping("/test")
     public ResponseEntity<String> testAPI() {
         return ResponseEntity.ok("successful");
     }
 
-    /**
-     * spring security test
-     *
-     * @return
-     */
     @GetMapping("/auth/test")
     public ResponseEntity<String> testAuthAPI() {
         return ResponseEntity.ok("successful");

--- a/src/main/java/com/epi/epilog/app/dto/AuthFormDto.java
+++ b/src/main/java/com/epi/epilog/app/dto/AuthFormDto.java
@@ -1,6 +1,7 @@
 package com.epi.epilog.app.dto;
 
 import com.epi.epilog.app.domain.enums.GenderType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/epi/epilog/app/service/checklist/MedicationCommandService.java
+++ b/src/main/java/com/epi/epilog/app/service/checklist/MedicationCommandService.java
@@ -171,7 +171,7 @@ public class MedicationCommandService {
      * @return
      */
     @Transactional
-    public CommonResponseDto.CommonResponse deleteMedication(CustomUserDetails userInfo, Long medicationId) {
+    public void deleteMedication(CustomUserDetails userInfo, Long medicationId) {
         Member member = memberRepository.findById(userInfo.getMember().getId())
                 .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
 
@@ -189,11 +189,6 @@ public class MedicationCommandService {
         }
 
         medicationRepository.delete(medication);
-
-        return CommonResponseDto.CommonResponse.builder()
-                .success(true)
-                .message("삭제되었습니다.")
-                .build();
     }
 
     /**

--- a/src/main/java/com/epi/epilog/global/config/SecurityConfig.java
+++ b/src/main/java/com/epi/epilog/global/config/SecurityConfig.java
@@ -28,7 +28,9 @@ public class SecurityConfig {
             "/detection/fall",
 //            "/api/diabetes/**",
             "/test",
-            "/ws/**"
+            "/ws/**",
+            "/swagger-ui/**",
+            "/v3/api-docs/**"
     };
 
     @Bean

--- a/src/main/java/com/epi/epilog/global/config/SwaggerConfig.java
+++ b/src/main/java/com/epi/epilog/global/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package com.epi.epilog.global.config;
+
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Dialog Documentation")
+                .description("Dialog Swagger UI")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/com/epi/epilog/global/exception/ErrorCode.java
+++ b/src/main/java/com/epi/epilog/global/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     INVALID_ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, 400, "올바르지 않은 파라미터입니다."),
     INVALID_DATETIME_ERROR(HttpStatus.BAD_REQUEST, 400, "올바르지 않은 시간 포맷입니다."),
     INVALID_DATE_ERROR(HttpStatus.BAD_REQUEST, 400, "올바르지 않은 날짜 포맷입니다."),
+    FAIL_TO_CONVERSION_PDF(HttpStatus.BAD_REQUEST, 400, "PDF 변환에 실패했습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, 404, "데이터베이스에 존재하지 않습니다."),
     INVALID_FORMAT_ERROR(HttpStatus.BAD_REQUEST, 400, "올바르지 않은 포맷입니다."),
     INVALID_TYPE_ERROR(HttpStatus.BAD_REQUEST, 400, "올바르지 않은 타입입니다."),

--- a/src/main/java/com/epi/epilog/global/exception/ErrorCode.java
+++ b/src/main/java/com/epi/epilog/global/exception/ErrorCode.java
@@ -24,8 +24,8 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 401, "유효하지 않은 토큰입니다"),
 
     // 2xxx
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, 2000, "유저를 찾을 수 없습니다."),
-    MEDICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, 4000, "약을 찾을 수 없습니다"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 2000, "유저를 찾을 수 없습니다."),
+    MEDICATION_NOT_FOUND(HttpStatus.NOT_FOUND, 4000, "약을 찾을 수 없습니다"),
 
     // 3xxx
     OVER_COUNT_DIABETES(HttpStatus.BAD_REQUEST, 3000, "최대 입력 개수를 넘었습니다."),

--- a/src/main/java/com/epi/epilog/global/exception/ErrorResponse.java
+++ b/src/main/java/com/epi/epilog/global/exception/ErrorResponse.java
@@ -1,6 +1,7 @@
 package com.epi.epilog.global.exception;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -13,14 +14,16 @@ import java.util.List;
 @Builder
 @Getter
 @RequiredArgsConstructor
+@Schema(description = "예외 처리 응답")
 public class ErrorResponse {
+    @Schema(description = "요청 성공 여부")
     private final boolean success = false;
+    @Schema(description = "HTTP Status")
     private final HttpStatus httpStatus;
+    @Schema(description = "Dialog Status")
     private final int code;
+    @Schema(description = "설명")
     private final String message;
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private final List<ValidationError> errors;
 
     public static ErrorResponse of(HttpStatus httpStatus, int code, String message) {
         return ErrorResponse.builder()
@@ -35,7 +38,6 @@ public class ErrorResponse {
                 .httpStatus(httpStatus)
                 .code(code)
                 .message(message)
-                .errors(ValidationError.of(bindingResult))
                 .build();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,16 @@ spring:
     multipart:
       max-file-size: 200MB
 
+springdoc:
+  packages-to-scan: com.epi.epilog
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+
 jwt:
   expiration_time: 86400000 #1일
   secret: ${JWT_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
   swagger-ui:
-    path: /
+    path: /swagger-ui
     disable-swagger-default-url: true
     display-request-duration: true
     operations-sorter: alpha


### PR DESCRIPTION
## Work Description
> Swagger 도입

- Swagger 도입
- Http Status 수정

#### Swagger 도입 관련
**기존 노션 API명세서가 빈번한 코드 업데이트로 인해 동기화되지 않는 문제가 있어서 Swagger를 도입**했습니다. 기본적인 설정은 해놨으나 Response 모든 경우의 수를 업데이트하지 못했습니다. 테스트코드 추가하면서 관련 ApiResponse도 같이 추가하겠습니다.

>워치 애플리케이션에서 사용할 API를 먼저 만들다보니 Controller의 구분이 제멋대로라는 느낌을 받았습니다. 수정하고 싶었으나 클라이언트와의 상의 없이 수정했을 때 일이 늘어날 것 같아서 보류합니다.

#### HTTP Status 수정 관련
기본적인 응답 성공은 200OK로 처리했습니다. 그러나 생성 및 삭제의 경우 200OK는 HTTP Status로 전달하기 부정확하다고 생각하여 수정했습니다. 
수정 요청은 200OK로 통일했습니다. 이후 더 고민을 하면서 수정하게 될 것 같습니다. 
- 생성 -> 201CREATED
- 삭제 -> 204NOCONTENT

## ISSUE
- closed #162

## Screenshot
- 전체 Tag
 ![image](https://github.com/user-attachments/assets/26204cb6-fbfd-42f6-a118-4670432e65cf)
- Auth 도메인
![image](https://github.com/user-attachments/assets/7a96dc63-c995-4fcb-8411-b5bce4a62960)
- Log 도메인
![image](https://github.com/user-attachments/assets/3ba903bf-29df-4ac8-8292-9e364e9324bf)
- ApiResponse 예시 (업데이트 예정)
![image](https://github.com/user-attachments/assets/e51620f8-90b5-475f-8c67-56d22da26df4)

## To Reviewers
호스트 `/swagger-ui/index.html` 경로로 접근하면 swagger 문서를 확인하실 수 있습니다.
수정된 내용이 많아서 모든 스크린샷을 첨부하지 못했습니다. 해당 경로에서 확인해주세요.

Diabetes 컨트롤러와 Log 컨트롤러, Medication 컨트롤러와 Medicine 컨트롤러를 나눌 필요가 없어서 합칠지 고민 중입니다. 엔드포인트 변경이 있을 시 회의 시간에 공지드리겠습니다.

## Reference
[Swagger 참고](https://velog.io/@juns1s/%EC%8A%A4%ED%94%84%EB%A7%81%EB%B6%80%ED%8A%B8%EC%97%90-Swagger%EB%A5%BC-%EC%A0%81%EC%9A%A9%ED%95%B4%EB%B3%B4%EC%9E%90)
